### PR TITLE
Fixes #2

### DIFF
--- a/features/example.feature
+++ b/features/example.feature
@@ -1,29 +1,18 @@
-Feature: Use Cucumber as a manual test tool
+Feature: Running any Cucumber scenarios with the Crudecumber gem
 
   As a QA Engineer learning Cucumber, I want to write scenarios for a product
   and run them manually.
 
-  Scenario: Pass steps
-    Given my directory contains a features folder with at least 1 feature file
-    When I type "crudecumber" in the Terminal to run Crudecumber
-    And I press "p" or "enter" on the keyboard
-    Then the step should pass
+  Scenario: Run external feature file with Crudecumber
+    Given I have a feature file in a features directory
+    And I have the Crudecumber gem installed
+    When I run 'crudecumber'
+    Then I should be able to step through my scenarios manually
 
-  Scenario: Fail steps
-    Given my directory contains a features folder with at least 1 feature file
-    When I type "crudecumber" in the Terminal to run Crudecumber
-    And I press "f" or "x" on the keyboard
-    Then the step should fail
-    And I should be able to provide a reason for the failure
-
-  Scenario: Skip steps
-    Given my directory contains a features folder with at least 1 feature file
-    When I type "crudecumber" in the Terminal to run Crudecumber
-    And I press "s" on the keyboard
-    Then the step should be skipped
-
-  Scenario: Exit Crudecumber
-    Given my directory contains a features folder with at least 1 feature file
-    When I type "crudecumber" in the Terminal to run Crudecumber
-    And I press "ctrl+c" on the keyboard
-    Then Crudecumber should exit immediately
+  @bugs @#2
+  Scenario: Ignore local step definitions to avoid ambiguous matches
+    Given I have local step definitions for this step
+    And a default profile explicitly requiring the step_definitions folder
+    When I run 'crudecumber --v'
+    Then the local step definition should not be loaded
+    And I should be able to step through my scenarios manually

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,6 @@ You can append any of the usual Cucumber arguments to, for example, run a subset
 
 Crudecumber is in its infancy and will be capable of more in time. In the current release there are the following known issues:
 * **Crudecumber is not compatible with Cucumber 2.0 or above.** Even if you're not using Cucumber 2.0 but you have it installed, you'll have a problem with steps not being rendered until after they are passed, failed or skipped. The best way to avoid this is to use [rvm](https://rvm.io/) and use a separate gemset for your Cucumber 2.0 stuff.
-* Users who use profiles to require step definition files when running tests (using a ***cucumber.yml*** file) may get errors with ambiguous matches. This can be fixed by removing the ***-r*** arguments from your Default profile.
 * Crudecumber automatically opens an HTML report at the end of a test run and requires **launchy** to open it. If you are using bundler, you may see the error ***cannot load such file -- launchy (LoadError)***. This can be remedied by updating your Gemfile and doing a `bundle install`.
 * Cucumber Tables are not currently supported.
 * This tool has been developed and tested on Mac OSX and Linux. Windows users may have trouble getting it to run.

--- a/ruby-gem/crudecumber.gemspec
+++ b/ruby-gem/crudecumber.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'crudecumber'
-  s.version     = '0.1.3'
+  s.version     = '0.1.3.dev'
   s.date        = '2015-06-15'
   s.summary     = 'Crudecumber 0.1.3'
   s.description = "Manually run through your Cucumber scenarios.\n

--- a/ruby-gem/crudecumber.gemspec
+++ b/ruby-gem/crudecumber.gemspec
@@ -1,12 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = 'crudecumber'
-  s.version     = '0.1.3.dev'
+  s.version     = '0.1.4'
   s.date        = '2015-06-15'
-  s.summary     = 'Crudecumber 0.1.3'
+  s.summary     = 'Crudecumber 0.1.4'
   s.description = "Manually run through your Cucumber scenarios.\n
-  Run exactly as you would run Cucumber but instead use \"crudecumber\" followed
-  by your usual arguments. May not work if you use profiles to manually require
-  automation step definitions."
+  Run exactly as you would run Cucumber but instead use \'crudecumber\' followed
+  by your usual arguments."
   s.author      = ['Dan Buckland']
   s.email       = 'danbucklan@gmail.com'
   s.files       = Dir['lib/**/**/*'] + Dir['bin/*']

--- a/ruby-gem/lib/crudecumber.rb
+++ b/ruby-gem/lib/crudecumber.rb
@@ -24,7 +24,7 @@ end
 
 STDOUT.sync = true
 arguments = ARGV
-cmd = "cucumber #{arguments.join(' ')} -r #{steps} -r #{support_files} "\
+cmd = "cucumber #{arguments.join(' ')} -e features/step_definitions -r #{steps} -r #{support_files} "\
       '-f Crudecumber::Formatter -f Crudecumber::Report '\
       '-o crudecumber_results.html'
 log cmd

--- a/ruby-gem/lib/crudecumber.rb
+++ b/ruby-gem/lib/crudecumber.rb
@@ -24,7 +24,8 @@ end
 
 STDOUT.sync = true
 arguments = ARGV
-cmd = "cucumber #{arguments.join(' ')} -e features/step_definitions -r #{steps} -r #{support_files} "\
+cmd = "cucumber #{arguments.join(' ')} -e features/step_definitions "\
+      "-r #{steps} -r #{support_files} "\
       '-f Crudecumber::Formatter -f Crudecumber::Report '\
       '-o crudecumber_results.html'
 log cmd


### PR DESCRIPTION
Fixed the ambiguous matching issue by making it so that when Cucumber is run, it will automatically run with '-e features/step_definitions'. This should prevent the ambiguous match issue occurring for most users.
