### PR TITLE
Closes #4

### DIFF
--- a/features/example.feature
+++ b/features/example.feature
@@ -31,11 +31,11 @@ Feature: Running any Cucumber scenarios with the Crudecumber gem
     Given I have a table full of examples
     And <country> has <tourists> visitors each year
     And an area of <area>
-    When I run 'crudecumber -x'
+    When I run 'crudecumber'
     Then I should be able to step through each scenario manually
 
-  Examples:
-    | country      | area     | tourists  |
-    | Vatican City | 0.44km^2 | 4,300,000 |
-    | Monaco       | 1.95km^2 | 328,000   |
-    | San Marino   | 61km^2   | 70,000    |
+    Examples:
+      | country      | area     | tourists  |
+      | Vatican City | 0.44km^2 | 4,300,000 |
+      | Monaco       | 1.95km^2 | 328,000   |
+      | San Marino   | 61km^2   | 70,000    |

--- a/features/example.feature
+++ b/features/example.feature
@@ -16,3 +16,26 @@ Feature: Running any Cucumber scenarios with the Crudecumber gem
     When I run 'crudecumber --v'
     Then the local step definition should not be loaded
     And I should be able to step through my scenarios manually
+
+  @tables
+  Scenario: Allow testers to manually run scenarios with tables
+    Given I have a scenario that contains the following table:
+      | Javan Slow Loris    |
+      | Rondo Dwarf Galago  |
+      | Brown Spider Monkey |
+    When I run 'crudecumber'
+    Then I should be able to step through this scenario manually
+
+  @tables
+  Scenario Outline: Allow testers to manually run scenario outlines
+    Given I have a table full of examples
+    And <country> has <tourists> visitors each year
+    And an area of <area>
+    When I run 'crudecumber -x'
+    Then I should be able to step through each scenario manually
+
+  Examples:
+    | country      | area     | tourists  |
+    | Vatican City | 0.44km^2 | 4,300,000 |
+    | Monaco       | 1.95km^2 | 328,000   |
+    | San Marino   | 61km^2   | 70,000    |

--- a/ruby-gem/lib/crudecumber.rb
+++ b/ruby-gem/lib/crudecumber.rb
@@ -24,7 +24,7 @@ end
 
 STDOUT.sync = true
 arguments = ARGV
-cmd = "cucumber #{arguments.join(' ')} -e features/step_definitions "\
+cmd = "cucumber #{arguments.join(' ')} -x -e features/step_definitions "\
       "-r #{steps} -r #{support_files} "\
       '-f Crudecumber::Formatter -f Crudecumber::Report '\
       '-o crudecumber_results.html'

--- a/ruby-gem/lib/crudecumber/crudecumber_steps.rb
+++ b/ruby-gem/lib/crudecumber/crudecumber_steps.rb
@@ -2,7 +2,7 @@
 # Essentially listens for the keys "return", "p", "f", "x" and "s" and then
 # decides whether to pass, fail or skip the step being run.
 
-Then(/^.*$/) do
+Then(/^.*$/) do | *x |
   Cucumber.trap_interrupt
   key = capture_key
   if skipped?(key)


### PR DESCRIPTION
Added basic support for tables by adding an optional parameter to the catch all step definition that Crudecumber uses. Added '-x' as an argument when Cucumber is run to force scenario outlines to expand, allowing testers to manually step through each example.
