### PR TITLE
Feature/better formatting for docstrings #13

### DIFF
--- a/ruby-gem/crudecumber.gemspec
+++ b/ruby-gem/crudecumber.gemspec
@@ -1,11 +1,12 @@
 Gem::Specification.new do |s|
   s.name        = 'crudecumber'
-  s.version     = '0.3.1'
+  s.version     = '0.4.0'
   s.date        = Date.today.to_s
-  s.summary     = "Crudecumber #{s.version}"
+  s.summary     = "A manual Cucumber runner"
   s.description = "Manually run through your Cucumber scenarios.\n
+  Hit \'P\' to pass a step, \'F\' to fail, or \'S\' to skip! \n
   Run exactly as you would run Cucumber but instead use \'crudecumber\' followed
-  by your usual arguments."
+  by your usual Cucumber arguments."
   s.author      = ['Dan Buckland']
   s.email       = 'me@danb.io'
   s.files       = Dir['lib/**/**/*'] + Dir['bin/*']

--- a/ruby-gem/features/handling_docstrings.feature
+++ b/ruby-gem/features/handling_docstrings.feature
@@ -14,9 +14,6 @@ Scenario: Display and overwrite Doc Strings
     =====================
     Doc Strings are handy for passing a larger piece of text to a step
     definition. The syntax is inspired from Python's Docstring syntax.
-
-    The text should be offset by delimiters consisting of three double-quote
-    marks on lines of their own.
     """
   When I run 'crudecumber'
   Then I should be able to step through this scenario manually
@@ -59,8 +56,5 @@ Scenario: Fail Doc String step
     =====================
     Doc Strings are handy for passing a larger piece of text to a step
     definition. The syntax is inspired from Python's Docstring syntax.
-
-    The text should be offset by delimiters consisting of three double-quote
-    marks on lines of their own.
     """
   Then this step should be shown as skipped and everything appear correctly

--- a/ruby-gem/features/handling_docstrings.feature
+++ b/ruby-gem/features/handling_docstrings.feature
@@ -8,7 +8,7 @@ Feature: Handling scenarios with Doc Strings
   handled well enough to be workable.
 
 Scenario: Display and overwrite Doc Strings
-  Given I have scenario that contains a Doc String like:
+  Given I have a scenario that contains a Doc String like:
     """
     What are Doc Strings?
     =====================
@@ -20,3 +20,47 @@ Scenario: Display and overwrite Doc Strings
     """
   When I run 'crudecumber'
   Then I should be able to step through this scenario manually
+
+Scenario: Skip Doc String step
+  Given I have a scenario that contains a Doc String
+  When I skip this step and it is marked as Pending by Crudecumber
+  Then this should be skipped and the following should appear correctly:
+    """ruby
+    STDOUT.sync = true
+    arguments = ARGV
+    cmd = "cucumber #{arguments.join(' ')} -x -e features/step_definitions "\
+          "-r #{steps} -r #{support_files} "\
+          '-f Crudecumber::Formatter -f Crudecumber::Report '\
+          '-o crudecumber_results.html'
+    log cmd
+    exit_code = system(cmd)
+    """
+
+Scenario: Mark Doc String step as Pending
+  Given I have a scenario that contains a Doc String
+  When I press 'S' to mark this Doc String step as Pending:
+    """ruby
+    STDOUT.sync = true
+    arguments = ARGV
+    cmd = "cucumber #{arguments.join(' ')} -x -e features/step_definitions "\
+          "-r #{steps} -r #{support_files} "\
+          '-f Crudecumber::Formatter -f Crudecumber::Report '\
+          '-o crudecumber_results.html'
+    log cmd
+    exit_code = system(cmd)
+    """
+  Then this step should be shown as skipped and everything appear correctly
+
+Scenario: Fail Doc String step
+  Given I have a scenario that contains a Doc String
+  When I fail the step containing this Doc String:
+    """
+    What are Doc Strings?
+    =====================
+    Doc Strings are handy for passing a larger piece of text to a step
+    definition. The syntax is inspired from Python's Docstring syntax.
+
+    The text should be offset by delimiters consisting of three double-quote
+    marks on lines of their own.
+    """
+  Then this step should be shown as skipped and everything appear correctly

--- a/ruby-gem/features/handling_docstrings.feature
+++ b/ruby-gem/features/handling_docstrings.feature
@@ -38,7 +38,7 @@ Scenario: Skip Doc String step
 
 Scenario: Mark Doc String step as Pending
   Given I have a scenario that contains a Doc String
-  When I press 'S' to mark this Doc String step as Pending:
+  When I press 's' to mark this Doc String step as Pending:
     """ruby
     STDOUT.sync = true
     arguments = ARGV

--- a/ruby-gem/features/handling_tables.feature
+++ b/ruby-gem/features/handling_tables.feature
@@ -17,7 +17,7 @@ Feature: Handling scenarios with tables
     Then I should be able to step through this scenario manually
 
   Scenario: Display and overwrite long tables
-    Given I have a scenario that contains the following table:
+    Given I have a scenario that contains the following longer table:
     | Most Endangered Species     | Number left |
     | Ivory-Billed Woodpecker     | A handful   |
     | Amur Leopard                | 20          |
@@ -31,6 +31,28 @@ Feature: Handling scenarios with tables
     | Saola/Asian Unicorn         | ?           |
     When I run 'crudecumber'
     Then I should be able to step through this scenario manually
+
+  Scenario: Fail step containing a table
+    Given I have a scenario that contains a table
+    When I fail the step containing this table:
+      | Gross monthly income:             | £2,208.33 |
+      | Personal allowance:               |   £883.33 |
+      | Total tax deductions:             |   £265.00 |
+      | National Insurance contributions: |   £184.40 |
+      | Total deductions:                 |   £449.40 |
+      | Net monthly income:               | £1,758.93 |
+    Then this step should be shown as skipped and everything appear correctly
+
+  Scenario: Mark step containing a table as Pending
+    Given I have a scenario that contains a table
+    When I press 's' to mark this table step as pending:
+      | Gross monthly income:             | £2,208.33 |
+      | Personal allowance:               |   £883.33 |
+      | Total tax deductions:             |   £265.00 |
+      | National Insurance contributions: |   £184.40 |
+      | Total deductions:                 |   £449.40 |
+      | Net monthly income:               | £1,758.93 |
+    Then this step should be shown as skipped and everything appear correctly
 
   @bugs @14
   Scenario: Render skipped tables only once

--- a/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
+++ b/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
@@ -11,8 +11,12 @@ module Crudecumber
   class Formatter < Cucumber::Formatter::Pretty
     def before_step(step)
       @io.printf "#{step.keyword}#{step.name}".indent(@scenario_indent + 2)
-      unless step.multiline_arg.nil?
+      case step.multiline_arg
+      when Cucumber::Ast::Table
         @io.printf "#{step.multiline_arg}".indent(@scenario_indent + 2)
+      when Cucumber::Ast::DocString
+        @io.printf "\n"
+        @io.printf "\"\"\"\n#{step.multiline_arg}\n\"\"\"".indent(@scenario_indent + 4)
       end
       super
     end
@@ -22,8 +26,7 @@ module Crudecumber
       when Cucumber::Ast::Table
         move_cursor_up(args[2].raw.length, args)
       when Cucumber::Ast::DocString
-        # TODO
-        p "I got a DocString"
+        move_cursor_up(args[2].lines.count + 1, args)
       else
         case args[3]
         when :failed

--- a/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
+++ b/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
@@ -18,20 +18,12 @@ module Crudecumber
     end
 
     def before_step_result(*args)
-      is_table = args[2].is_a?(Cucumber::Ast::Table)
-      table_rows = is_table ? args[2].raw.length : 0
-
-      if is_table # If there is a table
-        case args[3]
-        when :failed
-          @io.printf "\033[#{table_rows + 3}A"
-        when :pending
-          @io.printf "\033[#{table_rows + 1}A"
-        when :passed
-          @io.printf "\033[#{table_rows + 1}A"
-        when :skipped
-          @io.printf "\033[#{table_rows + 1}A"
-        end
+      case args[2]
+      when Cucumber::Ast::Table
+        move_cursor_up(args[2].raw.length, args)
+      when Cucumber::Ast::DocString
+        # TODO
+        p "I got a DocString"
       else
         case args[3]
         when :failed
@@ -40,6 +32,19 @@ module Crudecumber
       end
       @io.printf "\r\033[K"
       super
+    end
+
+    def move_cursor_up(height, args)
+      case args[3]
+      when :failed
+        @io.printf "\033[#{height + 3}A"
+      when :pending
+        @io.printf "\033[#{height + 1}A"
+      when :passed
+        @io.printf "\033[#{height + 1}A"
+      when :skipped
+        @io.printf "\033[#{height + 1}A"
+      end
     end
 
     def exception(_arg_1, _arg_2)

--- a/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
+++ b/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
@@ -28,10 +28,7 @@ module Crudecumber
       when Cucumber::Ast::DocString
         clear_multiline(args[2].lines.count + 1, args)
       else
-        case args[3]
-        when :failed
-          @io.printf "\033[2A"
-        end
+        @io.printf "\033[2A" if args[3] == :failed
       end
       @io.printf "\r\033[K"
       super
@@ -45,10 +42,6 @@ module Crudecumber
       end
     end
 
-    def exception(_arg_1, _arg_2)
-      # Do nothing
-    end
-
     def table_cell_value(value, status)
       return if !@table || @hide_this_step
       status ||= @status || :passed
@@ -56,8 +49,12 @@ module Crudecumber
       cell_text = escape_cell(value.to_s || '')
       padded = cell_text + (' ' * (width - cell_text.unpack('U*').length))
       prefix = cell_prefix(status)
-      @io.print(' ' + format_string("#{prefix}    #{padded}", status) + ::Cucumber::Term::ANSIColor.reset(' |'))
+      @io.print(' ' + format_string("#{prefix}#{padded}", status) + ::Cucumber::Term::ANSIColor.reset(' |'))
       @io.flush
+    end
+
+    def exception(_arg_1, _arg_2)
+      # Do nothing
     end
   end
 

--- a/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
+++ b/ruby-gem/lib/crudecumber/support/crudecumber_formatter.rb
@@ -24,9 +24,9 @@ module Crudecumber
     def before_step_result(*args)
       case args[2]
       when Cucumber::Ast::Table
-        move_cursor_up(args[2].raw.length, args)
+        clear_multiline(args[2].raw.length, args)
       when Cucumber::Ast::DocString
-        move_cursor_up(args[2].lines.count + 1, args)
+        clear_multiline(args[2].lines.count + 1, args)
       else
         case args[3]
         when :failed
@@ -37,16 +37,11 @@ module Crudecumber
       super
     end
 
-    def move_cursor_up(height, args)
-      case args[3]
-      when :failed
-        @io.printf "\033[#{height + 3}A"
-      when :pending
-        @io.printf "\033[#{height + 1}A"
-      when :passed
-        @io.printf "\033[#{height + 1}A"
-      when :skipped
-        @io.printf "\033[#{height + 1}A"
+    def clear_multiline(height, args)
+      if args[3] == :failed
+        @io.printf "\r" + ("\e[A\e[K" * (height + 3))
+      else
+        @io.printf "\r" + ("\e[A\e[K" * (height + 1))
       end
     end
 


### PR DESCRIPTION
Another one! Address poor formatting of DocStrings and gave me a chance to refactor some things!

Before:
<img width="1015" alt="screen shot 2017-08-25 at 16 07 30" src="https://user-images.githubusercontent.com/10908580/29719860-c8ae36bc-89af-11e7-9e3d-2b377de82d15.png">

After:
<img width="1099" alt="screen shot 2017-08-25 at 16 08 19" src="https://user-images.githubusercontent.com/10908580/29719873-d0eff8d8-89af-11e7-8f0c-1b7da797b1fb.png">